### PR TITLE
Fix psd variable ordering

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -39,7 +39,7 @@ end
 _polytype(m::JuMP.Model, ::PosPoly, x::MVT) where {MT<:AbstractMonomial, MVT<:AbstractVector{MT}} = MatPolynomial{JuMP.Variable, MT, MVT}
 
 function _constraintmatpoly!(m, p, ::Union{SOSPoly, Poly{true}})
-    push!(m.varCones, (:SDP, p.Q[1].col:p.Q[end].col))
+    push!(m.varCones, (:SDP, [p.Q[i, j].col for i in 1:size(p.Q, 1) for j in i:size(p.Q, 2)]))
 end
 function _constraintmatpoly!(m, p, ::DSOSPoly)
     n = length(p.x)


### PR DESCRIPTION
The ordering has been moved from row by row upper triangular to column by column upper triangular from MPB to MOI. SymMatrix now uses column by column upper triangular on master (see https://github.com/JuliaAlgebra/MultivariateMoments.jl/commit/58006b0bad979f4b86093397f1968dddfaa3396c) so using master SumOfSquares.jl and master MultivariateMoments.jl currently fails.
With the change of this PR, we access the SymMatrix using cartesian indexing the the behavior does not depend on the order the entries are stored in the SymMatrix which is safer.