### PR TITLE
🐛 Workaround for Julia segfault

### DIFF
--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -36,7 +36,7 @@ mutable struct SOSConstraint{MT <: AbstractMonomial, MVT <: AbstractVector{MT}, 
 end
 function SOSConstraint(slack::MatPolynomial{JS, MT, MVT},
                        zero_constraint::PolyJuMP.ZeroConstraint{MT, MVT, F}) where {MT <: AbstractMonomial, MVT <: AbstractVector{MT}, JS<:JuMP.AbstractJuMPScalar, F<:MOI.AbstractVectorFunction}
-    return SOSConstraint(slack, zero_constraint, MatPolynomial{JS, MT, MVT}[])
+    return SOSConstraint{MT, MVT, JS, F}(slack, zero_constraint, MatPolynomial{JS, MT, MVT}[])
 end
 
 certificate_monomials(c::PolyJuMP.PolyConstraintRef) = certificate_monomials(PolyJuMP.getdelegate(c))


### PR DESCRIPTION
This shouldn't be necessary but on some situations like the one given in #48 not giving these types explicitely leaves to a segfault.
The bug does not only depend on the types of the arguments which makes it tricky to reproduce.

Closes #48