### PR TITLE
Remove example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,44 +37,6 @@ Some presentations on, or using, SumOfSquares:
   * Benoît Legat at the [JuMP Meetup 2017](http://www.juliaopt.org/meetings/mit2017/) [[Slides](http://www.juliaopt.org/meetings/mit2017/legat.pdf)] [[Video](https://youtu.be/kyo72yWYr54)]
   * [Joey Huchette at SIAM Opt 2017](https://docs.google.com/presentation/d/1ASfjB1TdLJmYxT0b6rnyGh9eLbMc-66bTOt3_3yvc90/edit?usp=sharing)
 
-The following example shows how to find lower bounds for the Goldstein-Price function using this package with [MultivariatePolynomial](https://github.com/JuliaAlgebra/MultivariatePolynomials.jl) and [PolyJuMP](https://github.com/JuliaOpt/PolyJuMP.jl).
-
-```julia
-using MultivariatePolynomials
-using JuMP
-using PolyJuMP
-using SumOfSquares
-using DynamicPolynomials
-using Mosek
-
-# Create symbolic variables (not JuMP decision variables)
-@polyvar x1 x2
-
-# Create a Sum of Squares JuMP model with the Mosek solver
-m = SOSModel(solver = MosekSolver())
-
-# Create a JuMP decision variable for the lower bound
-@variable m γ
-
-# f(x) is the Goldstein-Price function
-f1 = x1+x2+1
-f2 = 19-14*x1+3*x1^2-14*x2+6*x1*x2+3*x2^2
-f3 = 2*x1-3*x2
-f4 = 18-32*x1+12*x1^2+48*x2-36*x1*x2+27*x2^2
-
-f = (1+f1^2*f2)*(30+f3^2*f4)
-
-# Constraints f(x) - γ to be sum of squares
-@constraint m f >= γ
-
-@objective m Max γ
-
-status = solve(m)
-
-# The lower bound found is 3
-println(getobjectivevalue(m))
-```
-
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-stable-url]: https://juliaopt.github.io/SumOfSquares.jl/stable


### PR DESCRIPTION
This example is long and not particularly helpful, it's better to redirect to the examples folder and the documentation. Also it does not work with CSDP