### PR TITLE
Reexport JuMP

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ MultivariateMoments 0.1.0
 MathOptInterface 0.8
 JuMP 0.18.2+
 PolyJuMP 0.2 0.3
+Reexport

--- a/src/SumOfSquares.jl
+++ b/src/SumOfSquares.jl
@@ -17,7 +17,9 @@ include("sosdec.jl")
 
 include("certificate.jl")
 
-using JuMP
+import Reexport
+
+Reexport.@reexport using JuMP
 using PolyJuMP
 export Poly
 


### PR DESCRIPTION
If you do `using SumOfSquares`, 99% of the time you also need to do `using JuMP` so it's probably better to do that automatically.
What do you think ?