### PR TITLE
✨ Add multipartite newton polytope computation

### DIFF
--- a/examples/Sum-of-Squares Matrices.ipynb
+++ b/examples/Sum-of-Squares Matrices.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Consider the symmetric polynomial matrix (taken from [Example 3.77, BPT13])\n",
+    "$$P(x) =\n",
+    "\\begin{bmatrix}\n",
+    "    x^2 - 2x + 2 & x\\\\\n",
+    "    x            & x^2\n",
+    "\\end{bmatrix}.$$\n",
+    "We could like to know whether $P(x)$ is positive semidefinite for all $x \\in \\mathbb{R}$.\n",
+    "\n",
+    "[BPT12] Blekherman, G.; Parrilo, P. A. & Thomas, R. R.\n",
+    "*Semidefinite Optimization and Convex Algebraic Geometry*.\n",
+    "Society for Industrial and Applied Mathematics, **2012**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2×2 Array{Polynomial{true,Int64},2}:\n",
+       " x² - 2x + 2  x \n",
+       " x            x²"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "using DynamicPolynomials\n",
+    "@polyvar x\n",
+    "P = [x^2 - 2x + 2 x\n",
+    "            x     x^2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A sufficient condition for a symmetric polynomial matrix $P(x)$ to be positive semidefinite for all $x$ is to the existence of a matrix $M(x)$ such that $P(x) = M^\\top(x) M(x)$. If such matrix $M$ exists, we say that the matrix is an \\emph{sos matrix} (see [Definition 3.76, BPT13]).\n",
+    "While determining whether $P(x)$ is positive semidefinite for all $x$, is NP-hard (checking nonnegativity of a polynomial is reduced to this problem for $1 \\times 1$ matrices), checking whether $P(x)$ is an sos matrix is an sos program."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "using SumOfSquares"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first need to pick an SDP solver, see [here](http://www.juliaopt.org/) for a list of the available choices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using CSDP\n",
+    "factory = with_optimizer(CSDP.Optimizer, printlevel=0);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using MathOptInterfaceMosek\n",
+    "factory = with_optimizer(MosekOptimizer, QUIET=true);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OPTIMAL::TerminationStatusCode = 1"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = SOSModel(factory)\n",
+    "mat_cref = @constraint(model, P in PSDCone())\n",
+    "JuMP.optimize!(model)\n",
+    "JuMP.termination_status(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While the reformulation of sos matrix to sos polynomial is rather simple, as explained in the \"Sum-of-Squares reformulation\" section below, there is a technical subtelty about the Newton polytope that if not handled correctly may result in an SDP of large size with bad numerical behavior. For this reason, it is recommended to model sos *matrix* constraints as such as will be shown in this notebook and not do the formulation manually unless there is a specific reason to do so.\n",
+    "\n",
+    "As we can verify as follows, only 4 monomials are used using the sos *matrix* constraint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element MonomialVector{true}:\n",
+       " x##365\n",
+       " x##367\n",
+       " ##365 \n",
+       " ##367 "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "getslack(mat_cref).x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sum-of-Squares reformulation\n",
+    "\n",
+    "One way to obtain the reduction to an sos program is to create an intermediate vector of variable $y$ and check whether the polynomial $p(x, y) = y^\\top P(x) y$ is sos.\n",
+    "However, special care is required when approximating the Newton polytope of $p(x, y)$. Indeed, for instance if the entries of $P(x)$ are quadratic forms then the Newton polytope of $p(x, y)$ is the cartesian product between the Newton polytope of $y^\\top y$ and the Newton polytope of $x^\\top x$. In other words, $p(x, y)$ belongs to a family of quartic forms called biquadratic forms. This fact is important when generating the semidefinite program so that only bilinear monomials are used. So if the cheap outer approximation is used (instead of the exact polyhedral computation) for the newton polytope then it is important to use a multipartite computation approximation of the newton polytope. The multipartie exact approach may perform worse compared to the unipartite exact in certain cases though. Consider for instance the polynomial matrix $\\mathrm{Diag}(x_1^1, x_2^2)$ for which $p(x, y) = x_1^2y_1^2 + x_2^2y_2^2$. For this polynomial, only the monomials $x_1y_1$ and $x_2y_2$ are needed in the SDP reformulation while the multipartite approach, as it will compute the Newton polytope as a cartesian product, will not see the dependence between $x$ and $y$ in the presence of monomials and will also select the monomials $x_1y_2$ and $x_2y_1$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$ x^{2}y_{1}^{2} + x^{2}y_{2}^{2} - 2xy_{1}^{2} + 2xy_{1}y_{2} + 2y_{1}^{2} $$"
+      ],
+      "text/plain": [
+       "x²y₁² + x²y₂² - 2xy₁² + 2xy₁y₂ + 2y₁²"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@polyvar y[1:2]\n",
+    "p = vec(y)' * P * vec(y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OPTIMAL::TerminationStatusCode = 1"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = SOSModel(factory)\n",
+    "cref = @constraint(model, p in SOSCone())\n",
+    "JuMP.optimize!(model)\n",
+    "JuMP.termination_status(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see below, 6 monomials (instead of the 4 monomials with the sos *matrix* constraint) have been used as the unipartite cheap outer approximation was used for the Newton Polytope."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6-element MonomialVector{true}:\n",
+       " xy₁ \n",
+       " xy₂ \n",
+       " y₁y₂\n",
+       " x   \n",
+       " y₁  \n",
+       " y₂  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "getslack(cref).x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.0.3",
+   "language": "julia",
+   "name": "julia-1.0"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.0.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/certificate.jl
+++ b/src/certificate.jl
@@ -1,45 +1,97 @@
 # Inspired from SOSTools
-export getmonomialsforcertificate, randpsd, randsos
+export randpsd, randsos
 
 cfld(x::NTuple{2,Int}, n) = (cld(x[1], n), fld(x[2], n))
 
-# TODO sparse with Newton polytope (Polyhedra.jl for convex hull)
-function _getmonomialsforcertificate(X::AbstractVector{<:AbstractMonomial}, sparse=:No)
-    if sparse == :No
-        # Cheap approximation of the convex hull as the approximation of:
-        #
-        # z such that mindegree < sum(z) < maxdegree
-        # |\
-        # |#\ <-------- sum(z) = maxdegree
-        # |##\
-        # |\<-\-------- sum(z) = mindegree
-        # | \##\
-        # +---------
-        #
-        # and:
-        #
-        # z such that minmultideg < z < maxmultideg
-        # | +----+ <--- maxmultidegree
-        # | |####|
-        # | |####|
-        # | +----+
-        # | ^---------- minmultidegree
-        # +---------
-        mindeg, maxdeg = cfld(extdegree(X), 2)
-        n = nvariables(X)
-        minmultideg, maxmultideg = Vector{Int}(undef, n), Vector{Int}(undef, n)
-        for i in 1:n
-            exponent_i(m) = exponents(m)[i]
-            minmultideg[i] = cld(mapreduce(exponent_i, min, X), 2)
-            maxmultideg[i] = fld(mapreduce(exponent_i, max, X), 2)
-        end
-        monomials(variables(X), mindeg:maxdeg,
-                  m -> all(minmultideg .<= exponents(m) .<= maxmultideg))
+function sub_extdegree(X::AbstractVector{<:AbstractMonomial}, vars)
+    if isempty(X)
+        return (0, 0)
     else
-        error("Not supported yet :(")
+        return extrema(map(mono -> sum(var -> degree(mono, var), vars), X))
     end
 end
-getmonomialsforcertificate(X::AbstractVector, sparse=:No) = _getmonomialsforcertificate(monovec(X), sparse)
+
+# Cheap approximation of the convex hull as the approximation of:
+#
+# z such that mindegree < sum(z) < maxdegree
+# |\
+# |#\ <-------- sum(z) = maxdegree
+# |##\
+# |\<-\-------- sum(z) = mindegree
+# | \##\
+# +---------
+#
+# and:
+#
+# z such that minmultideg < z < maxmultideg
+# | +----+ <--- maxmultidegree
+# | |####|
+# | |####|
+# | +----+
+# | ^---------- minmultidegree
+# +---------
+
+function _sub_half_newton_polytope(X::AbstractVector{<:AbstractMonomial},
+                                   extdeg, exp, vars)
+    mindeg, maxdeg = cfld(extdeg, 2)
+    n = length(vars)
+    minmultideg, maxmultideg = Vector{Int}(undef, n), Vector{Int}(undef, n)
+    for i in 1:n
+        exponent_i(mono) = exp(mono, i)
+        minmultideg[i] = cld(mapreduce(exponent_i, min, X), 2)
+        maxmultideg[i] = fld(mapreduce(exponent_i, max, X), 2)
+    end
+    monomials(vars, mindeg:maxdeg,
+              mono -> all(i -> minmultideg[i] <= exp(mono, i) <= maxmultideg[i],
+                          1:n))
+end
+
+function sub_half_newton_polytope(X::AbstractVector{<:AbstractMonomial},
+                                  vars)
+    _sub_half_newton_polytope(X, sub_extdegree(X, vars),
+                              (mono, i) -> degree(mono, vars[i]), vars)
+end
+
+# Multipartite
+# TODO we might do this recursively : do 2 parts, merge them, merge with next
+#      one and so on so that the filter at the end prunes more.
+function half_newton_polytope(X::AbstractVector, parts::Tuple)
+    if !all(i -> all(j -> i == j || isempty(parts[i] ∩ parts[j]),
+                     1:length(parts)),
+            1:length(parts))
+        throw(ArgumentError("Parts are not disjoint in multipartite Newton polytope estimation: $parts"))
+    end
+    # Some variables might be in no part...
+    missing = setdiff(variables(X), reduce(union, parts))
+    if isempty(missing)
+        all_parts = parts
+    else
+        # in that case, create a part with the missing ones
+        all_parts = (parts..., missing)
+    end
+    if length(all_parts) == 1
+        # all variables on same part, fallback to shortcut
+        return half_newton_polytope(X, tuple())
+    end
+    monovecs = map(vars -> sub_half_newton_polytope(X, vars), all_parts)
+    # Cartesian product of the newton polytopes of the different parts
+    product = [prod(monos) for monos in Iterators.product(monovecs...)]
+    mindeg, maxdeg = cfld(extdegree(X), 2)
+    # We know that the degree inequalities are satisfied variable-wise and
+    # part-wise but for all variables together so we filter with that
+    return monovec(filter(mono -> mindeg <= degree(mono) <= maxdeg, product))
+end
+# Shortcut for more efficient `extdeg` and `exp` function in case all the
+# variables are in the same part
+function half_newton_polytope(X::AbstractVector, parts::Tuple{})
+    return _sub_half_newton_polytope(X, extdegree(X),
+                                     (mono, i) -> exponents(mono)[i],
+                                     variables(X))
+end
+
+function monomials_half_newton_polytope(X::AbstractVector, parts)
+    half_newton_polytope(monovec(X), parts)
+end
 
 function randpsd(n; r=n, eps=0.1)
     Q = randn(n,n)
@@ -50,7 +102,7 @@ end
 
 function _randsos(X::AbstractVector{<:AbstractMonomial}; r=-1, monotype=:Classic, eps=0.1)
     if monotype == :Classic
-        x = getmonomialsforcertificate(X)
+        x = monomials_half_newton_polytope(X, tuple())
     elseif monotype == :Gram
         x = X
     else

--- a/test/certificate.jl
+++ b/test/certificate.jl
@@ -1,7 +1,35 @@
 @testset "Monomial selection for certificate" begin
-    @polyvar x y
-    @test_throws ErrorException getmonomialsforcertificate([x*y, y^2], :Sparse)
-    @test getmonomialsforcertificate([x*y, y^2]) == [y]
+    @polyvar x y z
+    @testset "Multipartite error not disjoint: $parts" for parts in [([x], [x]),
+                                                                     ([x], [x, y]),
+                                                                     ([x], [y], [x, y])]
+        err = ArgumentError("Parts are not disjoint in multipartite Newton polytope estimation: $parts")
+        @test_throws err SumOfSquares.monomials_half_newton_polytope([x*y, y^2], parts)
+    end
+    @testset "Unipartite" begin
+        @test SumOfSquares.monomials_half_newton_polytope([x*y, y^2], tuple()) == [y]
+        @test isempty(SumOfSquares.monomials_half_newton_polytope([x, y], tuple()))
+        @test SumOfSquares.monomials_half_newton_polytope([x^2, y^2], tuple()) == [x, y]
+        @test SumOfSquares.monomials_half_newton_polytope([x^2, y^2], ([x, y],)) == [x, y]
+        @test SumOfSquares.monomials_half_newton_polytope([x^2, y^2], ([y, x],)) == [x, y]
+    end
+    @testset "Multipartite" begin
+        # In the part [y, z], the degree is between 0 and 2
+        X = [x^4, x^2*y^2, x^2*z^2, x^2*y*z, y*z]
+        @test SumOfSquares.monomials_half_newton_polytope(X, tuple()) == [x^2, x*y, x*z, y*z, x, y, z]
+        function full_test(X, Y, part1, part2)
+            @test SumOfSquares.monomials_half_newton_polytope(X, (part1,)) == Y
+            @test SumOfSquares.monomials_half_newton_polytope(X, (part2,)) == Y
+            a = SumOfSquares.monomials_half_newton_polytope(X, (part2,))
+            @test SumOfSquares.monomials_half_newton_polytope(X, (part1, part2)) == Y
+            @test SumOfSquares.monomials_half_newton_polytope(X, (part2, part1)) == Y
+        end
+        full_test(X, monovec([x^2, x*y, x*z,      x, y, z]), [x], [y, z])
+        full_test(X, monovec([x^2, x*y, x*z, y*z, x,    z]), [y], [x, z])
+        full_test(X, monovec([x^2, x*y, x*z, y*z, x, y   ]), [z], [x, y])
+        # FIXME: With recursive merging, it should give [x^2, x*y, x*z, x]
+        @test SumOfSquares.monomials_half_newton_polytope([x^4, x^2*y^2, x^2*z^2, x^2*y*z, y*z], ([x], [y], [z])) == [x^2, x*y, x*z, y*z, x, y, z]
+    end
 end
 
 @testset "Random SOS should be SOS with $(factory.constructor)" for factory in sdp_factories

--- a/test/choi.jl
+++ b/test/choi.jl
@@ -21,5 +21,6 @@
     @SDconstraint m C >= 0
 
     JuMP.optimize!(m)
+    @test JuMP.termination_status(m) == MOI.INFEASIBLE
     @test JuMP.dual_status(m) == MOI.INFEASIBILITY_CERTIFICATE
 end

--- a/test/simplematrixsos.jl
+++ b/test/simplematrixsos.jl
@@ -6,13 +6,17 @@
     P = [x^2-2x+2 x; x x^2]
     # Example 3.77
     m = SOSModel(factory)
-    @SDconstraint m P >= 0
+    mat_cref = @SDconstraint m P >= 0
     JuMP.optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
     @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
+    @test length(getslack(mat_cref).x) == 4
     # Example 3.79
     @polyvar y[1:2]
     M = SOSModel(factory)
-    @constraint M dot(vec(y), P*vec(y)) >= 0
+    cref = @constraint M dot(vec(y), P*vec(y)) >= 0
     JuMP.optimize!(M)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
     @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
+    @test length(getslack(cref).x) == 6
 end

--- a/test/sosdemo10.jl
+++ b/test/sosdemo10.jl
@@ -28,8 +28,14 @@
 
     JuMP.optimize!(m)
 
-    # Program is feasible, { x |((g0+g1) + theta)(theta - (g0+g1)) >=0 } contains { x | p <= gamma }
-    @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT || JuMP.primal_status(m) == MOI.NEARLY_FEASIBLE_POINT
+    # Program is feasible, that is, the set
+    # { x |((g0+g1) + theta)(theta - (g0+g1)) >=0 }
+    # contains the set
+    # { x | p <= gamma }
+
+    # ALMOST_OPTIMAL and NEARLY_FEASIBLE_POINT for CSDP
+    @test JuMP.termination_status(m) in [MOI.OPTIMAL, MOI.ALMOST_OPTIMAL]
+    @test JuMP.primal_status(m) in [MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT]
 
     #@show JuMP.value(s)
     #@show JuMP.value(g1)

--- a/test/sosdemo9.jl
+++ b/test/sosdemo9.jl
@@ -14,6 +14,7 @@
     @SDconstraint m P ⪰ 0
 
     JuMP.optimize!(m)
-    @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT ||
-          JuMP.primal_status(m) == MOI.NEARLY_FEASIBLE_POINT
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    # NEARLY_FEASIBLE_POINT for CSDP
+    @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
 end


### PR DESCRIPTION
This is implemented in SOSTools and gives an important reduction of monomials for SOS matrix constraints (see the notebook that is added in this PR).

Related to https://github.com/JuliaOpt/SumOfSquares.jl/issues/2