### PR TITLE
Add ProxSDP in solver tests

### DIFF
--- a/test/proxsdp_tests.jl
+++ b/test/proxsdp_tests.jl
@@ -1,0 +1,13 @@
+include("solver_preamble.jl")
+import ProxSDP
+factory = with_optimizer(ProxSDP.Optimizer, verbose=0)
+config = MOI.Test.TestConfig(atol=1e-3, rtol=1e-3)
+@testset "Linear" begin
+    Tests.linear_test(factory, config, ["dsos_horn"])
+end
+@testset "SOC" begin
+    Tests.soc_test(factory, config, ["sdsos_horn", "sdsos_bivariate_quadratic"])
+end
+@testset "SDP" begin
+    Tests.sd_test(factory, config, ["sos_horn", "sos_bivariate_quadratic"])
+end

--- a/test/solver_tests.jl
+++ b/test/solver_tests.jl
@@ -35,6 +35,7 @@ solver_test(:SDPA)
 
 # SDP+SOC solvers
 solver_test(:Mosek)
+solver_test(:ProxSDP)
 solver_test(:SeDuMi)
 solver_test(:SCS)
 


### PR DESCRIPTION
There are a few tests that fail. The horn test fail because ProxSDP gives `OPTIMIZE_NOT_CALLED` instead of ˘INFEASIBLE˘ as a termination status.
The bivariate quadratic tests fails with an error:
```
sos_bivariate_quadratic: Error During Test at /home/blegat/.julia/dev/SumOfSquares/test/Tests/utilities.jl:40
  Got exception outside of a @test
  BoundsError: attempt to access 6-element Array{Float64,1} at index [7:9]
  Stacktrace:
   [1] throw_boundserror(::Array{Float64,1}, ::Tuple{UnitRange{Int64}}) at ./abstractarray.jl:484
   [2] checkbounds at ./abstractarray.jl:449 [inlined]
   [3] getindex at ./array.jl:735 [inlined]
   [4] get(::ProxSDP.Optimizer, ::MathOptInterface.ConstraintDual, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables,MathOptInterface.SecondOrderCone}) at /home/blegat/.julia/packages/ProxSDP/jMT9u/src/MOI_wrapper.jl:673
   [5] get(::MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}}, ::MathOptInterface.ConstraintDual, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables,MathOptInterface.SecondOrderCone}) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:448
   [6] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}},MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Bridges.AllBridgedConstraints{Float64}}}, ::MathOptInterface.ConstraintDual, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables,MathOptInterface.SecondOrderCone}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/bridgeoptimizer.jl:236
   [7] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}},MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Bridges.AllBridgedConstraints{Float64}}}, ::MathOptInterface.ConstraintDual, ::MathOptInterface.Bridges.VectorSlackBridge{Float64,MathOptInterface.VectorAffineFunction{Float64},MathOptInterface.SecondOrderCone}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/slackbridge.jl:163
   [8] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}},MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Bridges.AllBridgedConstraints{Float64}}}, ::MathOptInterface.ConstraintDual, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64},MathOptInterface.SecondOrderCone}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/bridgeoptimizer.jl:231
   [9] _get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}},MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Bridges.AllBridgedConstraints{Float64}}}, ::MathOptInterface.ConstraintDual, ::MathOptInterface.Bridges.RSOCBridge{Float64,MathOptInterface.VectorAffineFunction{Float64}}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/rsocbridge.jl:77
   [10] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}},MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Bridges.AllBridgedConstraints{Float64}}}, ::MathOptInterface.ConstraintDual, ::MathOptInterface.Bridges.RSOCBridge{Float64,MathOptInterface.VectorAffineFunction{Float64}}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/rsocbridge.jl:83
   [11] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}},MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Bridges.AllBridgedConstraints{Float64}}}, ::MathOptInterface.ConstraintDual, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64},MathOptInterface.RotatedSecondOrderCone}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/bridgeoptimizer.jl:231
   [12] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}},MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Bridges.AllBridgedConstraints{Float64}}}, ::MathOptInterface.ConstraintDual, ::SumOfSquares.PositiveSemidefinite2x2Bridge{Float64,MathOptInterface.VectorAffineFunction{Float64}}) at /home/blegat/.julia/dev/SumOfSquares/src/psd2x2_bridge.jl:54
   [13] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}},MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Bridges.AllBridgedConstraints{Float64}}}, ::MathOptInterface.ConstraintDual, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables,SumOfSquares.PositiveSemidefinite2x2ConeTriangle}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/bridgeoptimizer.jl:231
   [14] get at /home/blegat/.julia/dev/SumOfSquares/src/generic_variable_bridge.jl:47 [inlined]
   [15] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}},MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Bridges.AllBridgedConstraints{Float64}}}, ::SumOfSquares.MomentMatrixAttribute, ::SumOfSquares.SOSPolynomialBridge{Float64,MathOptInterface.VectorAffineFunction{Float64},SemialgebraicSets.FullSpace,Union{GenericVariableBridge{Float64,Nonnegatives}, GenericVariableBridge{Float64,PositiveSemidefiniteConeTriangle}, GenericVariableBridge{Float64,EmptyCone}, GenericVariableBridge{Float64,PositiveSemidefinite2x2ConeTriangle}},MathOptInterface.PositiveSemidefiniteConeTriangle,PolyJuMP.MonomialBasis,DynamicPolynomials.Monomial{true},DynamicPolynomials.MonomialVector{true}}) at /home/blegat/.julia/dev/SumOfSquares/src/sos_polynomial_bridge.jl:142
   [16] get(::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ProxSDP.Optimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}},MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Bridges.AllBridgedConstraints{Float64}}}, ::SumOfSquares.MomentMatrixAttribute, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64},SumOfSquares.SOSPolynomialSet{SemialgebraicSets.FullSpace,SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle},PolyJuMP.MonomialBasis,DynamicPolynomials.Monomial{true},DynamicPolynomials.MonomialVector{true},Tuple{}}}) at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/bridgeoptimizer.jl:231
   [17] get(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}}, ::SumOfSquares.MomentMatrixAttribute, ::MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64},SumOfSquares.SOSPolynomialSet{SemialgebraicSets.FullSpace,SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle},PolyJuMP.MonomialBasis,DynamicPolynomials.Monomial{true},DynamicPolynomials.MonomialVector{true},Tuple{}}}) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:448
   [18] _moi_get_result(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{JuMP._MOIModel{Float64}}}, ::SumOfSquares.MomentMatrixAttribute, ::Vararg{Any,N} where N) at /home/blegat/.julia/packages/JuMP/HmKx8/src/JuMP.jl:584
   [19] get(::Model, ::SumOfSquares.MomentMatrixAttribute, ::ConstraintRef{Model,MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64},SumOfSquares.SOSPolynomialSet{SemialgebraicSets.FullSpace,SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle},PolyJuMP.MonomialBasis,DynamicPolynomials.Monomial{true},DynamicPolynomials.MonomialVector{true},Tuple{}}},PolyJuMP.PolynomialShape{DynamicPolynomials.Monomial{true},DynamicPolynomials.MonomialVector{true}}}) at /home/blegat/.julia/packages/JuMP/HmKx8/src/JuMP.jl:615
   [20] moment_matrix(::ConstraintRef{Model,MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64},SumOfSquares.SOSPolynomialSet{SemialgebraicSets.FullSpace,SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle},PolyJuMP.MonomialBasis,DynamicPolynomials.Monomial{true},DynamicPolynomials.MonomialVector{true},Tuple{}}},PolyJuMP.PolynomialShape{DynamicPolynomials.Monomial{true},DynamicPolynomials.MonomialVector{true}}}) at /home/blegat/.julia/dev/SumOfSquares/src/constraint.jl:134
   [21] bivariate_quadratic_test(::OptimizerFactory, ::MathOptInterface.Test.TestConfig, ::SumOfSquares.NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}) at /home/blegat/.julia/dev/SumOfSquares/test/Tests/bivariate_quadratic_test.jl:42
   [22] sos_bivariate_quadratic_test(::OptimizerFactory, ::MathOptInterface.Test.TestConfig) at /home/blegat/.julia/dev/SumOfSquares/test/Tests/bivariate_quadratic_test.jl:62
   [23] macro expansion at /home/blegat/.julia/dev/SumOfSquares/test/Tests/utilities.jl:41 [inlined]
   [24] sd_test(::OptimizerFactory, ::MathOptInterface.Test.TestConfig, ::Array{String,1}) at /home/blegat/.julia/dev/SumOfSquares/test/Tests/utilities.jl:41
   [25] sd_test(::OptimizerFactory, ::MathOptInterface.Test.TestConfig) at /home/blegat/.julia/dev/SumOfSquares/test/Tests/utilities.jl:36
   [26] top-level scope at /home/blegat/.julia/dev/SumOfSquares/test/proxsdp_tests.jl:12
   [27] top-level scope at /build/julia/src/julia-1.1.0/usr/share/julia/stdlib/v1.1/Test/src/Test.jl:1083
   [28] top-level scope at /home/blegat/.julia/dev/SumOfSquares/test/proxsdp_tests.jl:12
   [29] include at ./boot.jl:326 [inlined]
   [30] include_relative(::Module, ::String) at ./loading.jl:1038
   [31] include(::Module, ::String) at ./sysimg.jl:29
   [32] include(::String) at ./client.jl:403
   [33] top-level scope at none:0
```
cc @joaquimg @mariohsouto @guilhermebodin