### PR TITLE
Add COSMO to solver tests

### DIFF
--- a/test/cosmo_tests.jl
+++ b/test/cosmo_tests.jl
@@ -1,0 +1,13 @@
+include("solver_preamble.jl")
+using COSMO
+factory = with_optimizer(COSMO.Optimizer)
+config = MOI.Test.TestConfig(atol=1e-4, rtol=1e-4)
+@testset "Linear" begin
+    Tests.linear_test(factory, config)
+end
+@testset "SOC" begin
+    Tests.soc_test(factory, config)
+end
+@testset "SDP" begin
+    Tests.sd_test(factory, config)
+end

--- a/test/solver_tests.jl
+++ b/test/solver_tests.jl
@@ -34,6 +34,7 @@ solver_test(:CSDP)
 solver_test(:SDPA)
 
 # SDP+SOC solvers
+solver_test(:COSMO)
 solver_test(:Mosek)
 solver_test(:SeDuMi)
 solver_test(:SCS)


### PR DESCRIPTION
@migarstka It works like a charm, it passes all the tests with the tolerance `1e-4` recommended in https://github.com/JuliaOpt/JuMP.jl/pull/1941