### PR TITLE
Rename remainder -> newton_of_remainder

### DIFF
--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -87,7 +87,7 @@ end
 
 function default_ideal_certificate(
     domain::AbstractAlgebraicSet, cone, basis,
-    newton_polytope, maxdegree, sparsity::Sparsity, remainder::Bool)
+    newton_polytope, maxdegree, sparsity::Sparsity, newton_of_remainder::Bool)
 
     if sparsity isa VariableSparsity
         if maxdegree === nothing
@@ -100,7 +100,7 @@ function default_ideal_certificate(
         @assert sparsity isa NoSparsity
         c = default_ideal_certificate(domain, cone, basis, newton_polytope, maxdegree)
     end
-    if remainder && !(c isa SumOfSquares.Certificate.Remainder)
+    if newton_of_remainder && !(c isa SumOfSquares.Certificate.Remainder)
         return SumOfSquares.Certificate.Remainder(c)
     end
     return c
@@ -135,9 +135,9 @@ function JuMP.moi_set(
     newton_polytope::Tuple=tuple(),
     maxdegree::Union{Nothing, Int}=MP.maxdegree(monos),
     sparsity::Sparsity=NoSparsity(),
-    remainder::Bool=false,
+    newton_of_remainder::Bool=false,
     ideal_certificate=default_ideal_certificate(
-        domain, cone, basis, newton_polytope, maxdegree, sparsity, remainder),
+        domain, cone, basis, newton_polytope, maxdegree, sparsity, newton_of_remainder),
     certificate=default_certificate(
         domain, sparsity, ideal_certificate, cone, basis, maxdegree)
     )

--- a/test/Tests/BPT12e399.jl
+++ b/test/Tests/BPT12e399.jl
@@ -18,7 +18,7 @@ function BPT12e399_test(optimizer, config::MOIT.TestConfig, remainder::Bool)
 
     @polyvar x y
     if remainder
-        cref = @constraint(model, 10 - (x^2 + α*y) in SOSCone(), remainder = true,
+        cref = @constraint(model, 10 - (x^2 + α*y) in SOSCone(), newton_of_remainder = true,
                            maxdegree = nothing, domain = @set x^2 + y^2 == 1)
     else
         cref = @constraint(model, 10 - (x^2 + α*y) in SOSCone(), maxdegree = 2, domain = @set x^2 + y^2 == 1)

--- a/test/Tests/quartic_ideal.jl
+++ b/test/Tests/quartic_ideal.jl
@@ -13,7 +13,7 @@ function quartic_ideal_test(optimizer, config::MOIT.TestConfig,
     # Set {-1, 0, 1}
     K = @set x^3 == x
     p = (x^2 - 1)^2
-    cref = @constraint(model, p in SOSCone(), domain = K, maxdegree=degree, remainder = remainder)
+    cref = @constraint(model, p in SOSCone(), domain = K, maxdegree=degree, newton_of_remainder = remainder)
     optimize!(model)
 
     if remainder && (degree === nothing || degree < 4)


### PR DESCRIPTION
Rename `remainder` -> `newton_of_remainder` before we release.
This allows `remainder` to be used for https://github.com/JuliaOpt/SumOfSquares.jl/issues/11