### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/src/tutorials/Other Applications/bounds_in_probability.jl
+++ b/docs/src/tutorials/Other Applications/bounds_in_probability.jl
@@ -2,7 +2,7 @@
 
 #md # [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/Other Applications/bounds_in_probability.ipynb)
 #md # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/Other Applications/bounds_in_probability.ipynb)
-# **Adapted from**: SOSTOOLS' SOSDEMO8 (See Section 4.8 of [SOSTOOLS User's Manual](http://sysos.eng.ox.ac.uk/sostools/sostools.pdf))
+# **Adapted from**: SOSTOOLS' SOSDEMO8 (See Section 4.8 of [SOSTOOLS User's Manual](https://github.com/oxfordcontrol/SOSTOOLS/blob/SOSTOOLS400/docs/SOSTOOLS_400.pdf))
 
 using Test #src
 

--- a/docs/src/tutorials/Polynomial Optimization/bound_on_global_extremum.jl
+++ b/docs/src/tutorials/Polynomial Optimization/bound_on_global_extremum.jl
@@ -2,7 +2,7 @@
 
 #md # [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/Polynomial Optimization/bound_on_blobal_extremum.ipynb)
 #md # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/Polynomial Optimization/bound_on_global_extremum.ipynb)
-# **Adapted from**: SOSTOOLS' SOSDEMO3 (See Section 4.3 of [SOSTOOLS User's Manual](http://sysos.eng.ox.ac.uk/sostools/sostools.pdf))
+# **Adapted from**: SOSTOOLS' SOSDEMO3 (See Section 4.3 of [SOSTOOLS User's Manual](https://github.com/oxfordcontrol/SOSTOOLS/blob/SOSTOOLS400/docs/SOSTOOLS_400.pdf))
 
 using Test #src
 using DynamicPolynomials

--- a/docs/src/tutorials/Systems and Control/julia_set.jl
+++ b/docs/src/tutorials/Systems and Control/julia_set.jl
@@ -39,7 +39,7 @@ function in_set(x, c, m=2000)
 end
 
 # To sort of minimize a level set of a polynomial we minimize integral of that polynomial.
-# We borrow the following from https://doi.org/10.1080/00029890.2001.11919774
+# We borrow the following from [here](https://doi.org/10.1080/00029890.2001.11919774).
 
 using SpecialFunctions
 using DynamicPolynomials

--- a/docs/src/tutorials/Systems and Control/lyapunov_function_search.jl
+++ b/docs/src/tutorials/Systems and Control/lyapunov_function_search.jl
@@ -2,7 +2,7 @@
 
 #md # [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/Systems and Control/lyapunov_function_search.ipynb)
 #md # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/Systems and Control/lyapunov_function_search.ipynb)
-# **Adapted from**: SOSTOOLS' SOSDEMO2 (See Section 4.2 of [SOSTOOLS User's Manual](http://sysos.eng.ox.ac.uk/sostools/sostools.pdf))
+# **Adapted from**: SOSTOOLS' SOSDEMO2 (See Section 4.2 of [SOSTOOLS User's Manual](https://github.com/oxfordcontrol/SOSTOOLS/blob/SOSTOOLS400/docs/SOSTOOLS_400.pdf))
 
 using Test #src
 using DynamicPolynomials


### PR DESCRIPTION
- Fix broken hyperref to SOSTOOLS user's manual (References to chapters are still correct)
- Add hyperref to https://doi.org/10.1080/00029890.2001.11919774