### PR TITLE
Modify ImageBridge cost to make Hypatia choose KernelBridge

### DIFF
--- a/src/Bridges/Constraint/image.jl
+++ b/src/Bridges/Constraint/image.jl
@@ -188,13 +188,13 @@ function MOI.Bridges.added_constraint_types(
 end
 
 # The default cost of `1` makes `ImageBridge` win against `Variable.KernelBridge`
-# for solvers like Hypatia that natively support PSD as constrained variables
-# (where `KernelBridge` would be more natural). Bumping the cost shifts the
-# balance: for solvers that only support PSD as a constraint (e.g. Clarabel)
-# the `KernelBridge` fallback path is still strictly more expensive, so
-# `ImageBridge` remains the cheapest path; for solvers that support PSD as
-# constrained variables, `KernelBridge` now wins.
-MOI.Bridges.bridging_cost(::Type{<:ImageBridge}) = 3.0
+# for solvers that natively support PSD as constrained variables (e.g. Mosek's
+# `barvar` matrix variables), where `KernelBridge` would be more natural.
+# Bumping the cost by `1` shifts the balance: for solvers that only support PSD
+# as a constraint (e.g. Clarabel), the `KernelBridge` fallback path is still
+# strictly more expensive, so `ImageBridge` remains the cheapest path; for
+# solvers that support PSD as constrained variables, `KernelBridge` now wins.
+MOI.Bridges.bridging_cost(::Type{<:ImageBridge}) = 2.0
 
 function MOI.Bridges.Constraint.concrete_bridge_type(
     ::Type{<:ImageBridge{T}},

--- a/src/Bridges/Constraint/image.jl
+++ b/src/Bridges/Constraint/image.jl
@@ -187,6 +187,15 @@ function MOI.Bridges.added_constraint_types(
     ]
 end
 
+# The default cost of `1` makes `ImageBridge` win against `Variable.KernelBridge`
+# for solvers like Hypatia that natively support PSD as constrained variables
+# (where `KernelBridge` would be more natural). Bumping the cost shifts the
+# balance: for solvers that only support PSD as a constraint (e.g. Clarabel)
+# the `KernelBridge` fallback path is still strictly more expensive, so
+# `ImageBridge` remains the cheapest path; for solvers that support PSD as
+# constrained variables, `KernelBridge` now wins.
+MOI.Bridges.bridging_cost(::Type{<:ImageBridge}) = 3.0
+
 function MOI.Bridges.Constraint.concrete_bridge_type(
     ::Type{<:ImageBridge{T}},
     G::Type{<:MOI.AbstractVectorFunction},

--- a/test/Bridges/dummy.jl
+++ b/test/Bridges/dummy.jl
@@ -110,7 +110,7 @@ function MOI.supports(
 end
 
 function runtests()
-    for name in names(@__MODULE__; all=true)
+    for name in names(@__MODULE__; all = true)
         if startswith("$(name)", "test_")
             @testset "$(name)" begin
                 getfield(@__MODULE__, name)()

--- a/test/Bridges/dummy.jl
+++ b/test/Bridges/dummy.jl
@@ -146,7 +146,7 @@ function test_dummymosek_uses_kernel_bridge()
         optimizer,
         SumOfSquares.Bridges.Variable.KernelBridge{T},
     )
-    @test MOI.Bridges.bridging_cost(optimizer, S) == 8.0
+    @test MOI.Bridges.bridging_cost(optimizer, S) == 7.0
     @test !MOI.Bridges.is_variable_bridged(optimizer, S)
     return
 end

--- a/test/Bridges/dummy.jl
+++ b/test/Bridges/dummy.jl
@@ -1,0 +1,156 @@
+module TestDummy
+
+using Test
+import MathOptInterface as MOI
+import MultivariateBases as MB
+using DynamicPolynomials
+using SumOfSquares
+
+# `DummyMosek` is a stub `MOI.AbstractOptimizer` that mirrors the native
+# support pattern of Mosek (see `MosekTools.jl/src/constraint.jl`):
+# `MOI.PositiveSemidefiniteConeTriangle` is supported as constrained variables
+# (Mosek's `barvar` matrix variables) and `MOI.Scaled{PSDConeTriangle}` is
+# supported as a `VAF` constraint (Mosek's `ACC` affine conic constraints).
+# Only the `MOI.supports_*` methods are implemented which is enough for the
+# `LazyBridgeOptimizer` to build its cost graph and answer
+# `MOI.Bridges.bridging_cost` queries.
+mutable struct DummyMosek{T} <: MOI.AbstractOptimizer end
+
+DummyMosek() = DummyMosek{Float64}()
+
+MOI.is_empty(::DummyMosek) = true
+MOI.empty!(::DummyMosek) = nothing
+
+# Mosek `barvar` matrix variables.
+function MOI.supports_add_constrained_variables(
+    ::DummyMosek,
+    ::Type{MOI.PositiveSemidefiniteConeTriangle},
+)
+    return true
+end
+
+function MOI.supports_constraint(
+    ::DummyMosek{T},
+    ::Type{MOI.VectorOfVariables},
+    ::Type{
+        <:Union{
+            MOI.SecondOrderCone,
+            MOI.RotatedSecondOrderCone,
+            MOI.ExponentialCone,
+            MOI.DualExponentialCone,
+            MOI.PowerCone{T},
+            MOI.DualPowerCone{T},
+        },
+    },
+) where {T}
+    return true
+end
+
+# Mosek `ACC` affine conic constraints.
+function MOI.supports_constraint(
+    ::DummyMosek{T},
+    ::Type{MOI.VectorAffineFunction{T}},
+    ::Type{
+        <:Union{
+            MOI.Zeros,
+            MOI.Nonnegatives,
+            MOI.SecondOrderCone,
+            MOI.RotatedSecondOrderCone,
+            MOI.ExponentialCone,
+            MOI.DualExponentialCone,
+            MOI.PowerCone{T},
+            MOI.DualPowerCone{T},
+            MOI.GeometricMeanCone,
+            MOI.Scaled{MOI.PositiveSemidefiniteConeTriangle},
+        },
+    },
+) where {T}
+    return true
+end
+
+function MOI.supports_constraint(
+    ::DummyMosek{T},
+    ::Type{MOI.VariableIndex},
+    ::Type{
+        <:Union{
+            MOI.LessThan{T},
+            MOI.GreaterThan{T},
+            MOI.EqualTo{T},
+            MOI.Interval{T},
+        },
+    },
+) where {T}
+    return true
+end
+
+function MOI.supports_constraint(
+    ::DummyMosek{T},
+    ::Type{MOI.ScalarAffineFunction{T}},
+    ::Type{
+        <:Union{
+            MOI.LessThan{T},
+            MOI.GreaterThan{T},
+            MOI.EqualTo{T},
+            MOI.Interval{T},
+        },
+    },
+) where {T}
+    return true
+end
+
+MOI.supports(::DummyMosek, ::MOI.ObjectiveSense) = true
+
+function MOI.supports(
+    ::DummyMosek{T},
+    ::MOI.ObjectiveFunction{
+        <:Union{MOI.VariableIndex,MOI.ScalarAffineFunction{T}},
+    },
+) where {T}
+    return true
+end
+
+function runtests()
+    for name in names(@__MODULE__; all=true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+# Verify that with `DummyMosek` (a Mosek-like stub that natively supports
+# `PositiveSemidefiniteConeTriangle` as constrained variables) the bridges
+# added by `SumOfSquares.Bridges.add_all_bridges` route a `WeightedSOSCone`
+# constrained variable through `KernelBridge`. After removing `KernelBridge`
+# the only remaining route is the `ImageBridge` constraint-side fallback,
+# which is strictly more expensive.
+function test_dummymosek_uses_kernel_bridge()
+    T = Float64
+    @polyvar x y
+    optimizer = MOI.Bridges.full_bridge_optimizer(DummyMosek{T}(), T)
+    SumOfSquares.Bridges.add_all_bridges(optimizer, T)
+    set = SumOfSquares.WeightedSOSCone{MOI.PositiveSemidefiniteConeTriangle}(
+        MB.SubBasis{MB.Monomial}([y^4, x * y^3, x^2 * y^2, x^3 * y, x^4]),
+        [MB.SubBasis{MB.Monomial}([y^2, x * y, x^2])],
+        [MB.algebra_element(one(T) * x^0 * y^0)],
+    )
+    S = typeof(set)
+    # With every bridge enabled, `KernelBridge` (variable side) wins.
+    @test MOI.Bridges.bridging_cost(optimizer, S) == 6.0
+    @test MOI.Bridges.is_variable_bridged(optimizer, S)
+    # Removing `KernelBridge` exposes the `ImageBridge` constraint-side
+    # fallback, which goes through a free variable + `ImageBridge` chain.
+    MOI.Bridges.remove_bridge(
+        optimizer,
+        SumOfSquares.Bridges.Variable.KernelBridge{T},
+    )
+    @test MOI.Bridges.bridging_cost(optimizer, S) == 8.0
+    @test !MOI.Bridges.is_variable_bridged(optimizer, S)
+    return
+end
+
+end
+
+TestDummy.runtests()

--- a/test/Bridges/lazy.jl
+++ b/test/Bridges/lazy.jl
@@ -1,7 +1,6 @@
 module TestLazy
 
 using Test
-import Hypatia
 import Clarabel
 using DynamicPolynomials
 import MultivariateBases as MB
@@ -15,55 +14,6 @@ function runtests()
             end
         end
     end
-    return
-end
-
-# Verify that with a full bridge optimizer wrapping CSDP, the bridges added by
-# `SumOfSquares.Bridges.add_all_bridges` route a `WeightedSOSCone` constrained
-# variable through `KernelBridge`. CSDP only supports
-# `MOI.PositiveSemidefiniteConeTriangle` as constrained variables, which is
-# what `KernelBridge` produces. We follow the workaround documented in
-# `docs/src/tutorials/Noncommutative and Hermitian/chsh.jl`
-# (cf. https://github.com/jump-dev/MathOptInterface.jl/pull/3001) and remove
-# `ImageBridge` so the bridge optimizer picks the `KernelBridge` path.
-function test_hypatia_uses_kernel_bridge()
-    T = Float64
-    @polyvar x y
-    optimizer = MOI.instantiate(
-        Hypatia.Optimizer;
-        with_cache_type = T,
-        with_bridge_type = T,
-    )
-    SumOfSquares.Bridges.add_all_bridges(optimizer, T)
-    set = SumOfSquares.WeightedSOSCone{MOI.PositiveSemidefiniteConeTriangle}(
-        MB.SubBasis{MB.Monomial}([y^4, x * y^3, x^2 * y^2, x^3 * y, x^4]),
-        [MB.SubBasis{MB.Monomial}([y^2, x * y, x^2])],
-        [MB.algebra_element(one(T) * x^0 * y^0)],
-    )
-    S = typeof(set)
-    # With every bridge enabled, `KernelBridge` (variable side) wins.
-    @test MOI.Bridges.bridging_cost(optimizer, S) == 6.0
-    @test MOI.Bridges.is_variable_bridged(optimizer, S)
-    _, ci = MOI.add_constrained_variables(optimizer, set)
-    @test MOI.Bridges.bridge(optimizer, ci) isa
-          SumOfSquares.Bridges.Variable.KernelBridge
-    # Re-instantiate without `KernelBridge` so we measure the fallback path
-    # through `ImageBridge` instead.
-    optimizer = MOI.instantiate(
-        Hypatia.Optimizer;
-        with_cache_type = T,
-        with_bridge_type = T,
-    )
-    SumOfSquares.Bridges.add_all_bridges(optimizer, T)
-    MOI.Bridges.remove_bridge(
-        optimizer,
-        SumOfSquares.Bridges.Variable.KernelBridge{T},
-    )
-    @test MOI.Bridges.bridging_cost(optimizer, S) == 7.0
-    @test !MOI.Bridges.is_variable_bridged(optimizer, S)
-    _, ci = MOI.add_constrained_variables(optimizer, set)
-    @test MOI.Bridges.bridge(optimizer, ci) isa
-          SumOfSquares.Bridges.Constraint.ImageBridge
     return
 end
 

--- a/test/Bridges/lazy.jl
+++ b/test/Bridges/lazy.jl
@@ -35,19 +35,35 @@ function test_hypatia_uses_kernel_bridge()
         with_bridge_type = T,
     )
     SumOfSquares.Bridges.add_all_bridges(optimizer, T)
-    # TODO we use dualized SCS once https://github.com/jump-dev/MathOptInterface.jl/pull/3001 is done
-    MOI.Bridges.remove_bridge(
-        optimizer,
-        SumOfSquares.Bridges.Constraint.ImageBridge{T},
-    )
     set = SumOfSquares.WeightedSOSCone{MOI.PositiveSemidefiniteConeTriangle}(
         MB.SubBasis{MB.Monomial}([y^4, x * y^3, x^2 * y^2, x^3 * y, x^4]),
         [MB.SubBasis{MB.Monomial}([y^2, x * y, x^2])],
         [MB.algebra_element(one(T) * x^0 * y^0)],
     )
+    S = typeof(set)
+    # With every bridge enabled, `KernelBridge` (variable side) wins.
+    @test MOI.Bridges.bridging_cost(optimizer, S) == 6.0
+    @test MOI.Bridges.is_variable_bridged(optimizer, S)
     _, ci = MOI.add_constrained_variables(optimizer, set)
     @test MOI.Bridges.bridge(optimizer, ci) isa
           SumOfSquares.Bridges.Variable.KernelBridge
+    # Re-instantiate without `KernelBridge` so we measure the fallback path
+    # through `ImageBridge` instead.
+    optimizer = MOI.instantiate(
+        Hypatia.Optimizer;
+        with_cache_type = T,
+        with_bridge_type = T,
+    )
+    SumOfSquares.Bridges.add_all_bridges(optimizer, T)
+    MOI.Bridges.remove_bridge(
+        optimizer,
+        SumOfSquares.Bridges.Variable.KernelBridge{T},
+    )
+    @test MOI.Bridges.bridging_cost(optimizer, S) == 7.0
+    @test !MOI.Bridges.is_variable_bridged(optimizer, S)
+    _, ci = MOI.add_constrained_variables(optimizer, set)
+    @test MOI.Bridges.bridge(optimizer, ci) isa
+          SumOfSquares.Bridges.Constraint.ImageBridge
     return
 end
 
@@ -57,6 +73,7 @@ end
 # as a constraint, so the image-form bridge is the cheapest path).
 function test_clarabel_uses_image_bridge()
     T = Float64
+    F = MOI.VectorAffineFunction{T}
     @polyvar x y
     optimizer = MOI.instantiate(
         Clarabel.Optimizer;
@@ -69,11 +86,30 @@ function test_clarabel_uses_image_bridge()
         [MB.SubBasis{MB.Monomial}([y^2, x * y, x^2])],
         [MB.algebra_element(one(T) * x^0 * y^0)],
     )
+    S = typeof(set)
+    # `ImageBridge` directly supports `F`-in-`WeightedSOSCone`.
+    @test MOI.Bridges.bridging_cost(optimizer, F, S) == 7.0
     func =
         MOI.VectorAffineFunction{T}(MOI.VectorAffineTerm{T}[], T[5, -1, 2, 2])
     ci = MOI.add_constraint(optimizer, func, set)
     @test MOI.Bridges.bridge(optimizer, ci) isa
           SumOfSquares.Bridges.Constraint.ImageBridge
+    # Re-instantiate without `ImageBridge` to measure the fallback cost. The
+    # only remaining route is via a free variable + `KernelBridge`, but the
+    # full chain (functionize/scalarize/slack) is strictly more expensive than
+    # `ImageBridge`, so `ImageBridge` stays the chosen path when both are
+    # available.
+    optimizer = MOI.instantiate(
+        Clarabel.Optimizer;
+        with_cache_type = T,
+        with_bridge_type = T,
+    )
+    SumOfSquares.Bridges.add_all_bridges(optimizer, T)
+    MOI.Bridges.remove_bridge(
+        optimizer,
+        SumOfSquares.Bridges.Constraint.ImageBridge{T},
+    )
+    @test MOI.Bridges.bridging_cost(optimizer, F, S) == 8.0
     return
 end
 

--- a/test/Bridges/lazy.jl
+++ b/test/Bridges/lazy.jl
@@ -38,7 +38,7 @@ function test_clarabel_uses_image_bridge()
     )
     S = typeof(set)
     # `ImageBridge` directly supports `F`-in-`WeightedSOSCone`.
-    @test MOI.Bridges.bridging_cost(optimizer, F, S) == 7.0
+    @test MOI.Bridges.bridging_cost(optimizer, F, S) == 6.0
     func =
         MOI.VectorAffineFunction{T}(MOI.VectorAffineTerm{T}[], T[5, -1, 2, 2])
     ci = MOI.add_constraint(optimizer, func, set)


### PR DESCRIPTION
Hypatia and Mosek supports both constrained variables in PSD and affine PSD constraints, we should favor the kernel bridge as it is almost always results in a smaller reformulation, the only case where it's not smaller is basically quadratic polynomials.